### PR TITLE
CMake: update cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ include(GNUInstallDirs)
 
 include(${wxWidgets_USE_FILE})
 
-include_directories(src)
-
 file(GLOB_RECURSE SRC_LIST src/*.cpp)
 
 if(WIN32)
@@ -34,3 +32,4 @@ install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DOCDIR})
 install(FILES README.md DESTINATION ${CMAKE_INSTALL_FULL_DOCDIR})
 
 target_link_libraries(${PROJECT_NAME} ${wxWidgets_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-project(colorgrab)
+cmake_minimum_required(VERSION 3.10)
 
-cmake_minimum_required(VERSION 2.8.12)
+project(colorgrab LANGUAGES CXX)
+
 
 find_package(wxWidgets COMPONENTS core base xml xrc adv REQUIRED)
 


### PR DESCRIPTION
Support for CMake < 3.5 was removed with the introduction of CMake 4.0, and support for CMake < 3.10 was deprecated.  That should fix the AUR package.